### PR TITLE
Lost Connectivity managed for CalendarView

### DIFF
--- a/lib/view/pages/Calendar.dart
+++ b/lib/view/pages/Calendar.dart
@@ -122,6 +122,27 @@ class _CalendarState extends State<Calendar> {
                         child: Text("Error"),
                       ),
                     );
+                    case Status.OFFLINE:
+                    print("Log :: OFFLINE");
+                    return Expanded(
+                      child: Column(children: [
+                    Center(
+                      child: Text(
+                        "SIN CONEXIÓN A INTERNET",
+                        style: TextStyle(
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ),
+                    Center(
+                      child: Text(
+                        "Revisa tu conexión y refresca la página",
+                        style: TextStyle(
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ),
+                  ],),);
                   case Status.COMPLETED:
                     print("Log :: COMPLETED");
                     return Expanded(


### PR DESCRIPTION
There was an implementation that if there is no Wifi, the Calendar View shows a text that says that there is not connectivity and the view will be refresh